### PR TITLE
Issue 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,15 @@
 name = "disarmv7"
 version = "0.0.1"
 edition = "2021"
+authors = [
+	"Ivar Jönsson <ivajns-9@student.ltu.se>"
+]
+repository = "https://github.com/ivario123/disarmv7"
+license-file = "LICENSE"
+keywords = ["disassembly", "embedded", "arm", "armv7"]
+
+description = "Decodes armv7 instructions in to a rust enum."
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -2,7 +2,12 @@
 name = "arch"
 version = "0.1.0"
 edition = "2021"
+repository = "https://github.com/ivario123/disarmv7"
+license-file = "LICENSE"
+keywords = ["disassembly", "embedded", "arm", "armv7"]
 
+description = "Provides some armv7 architechture specific types."
+readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/arch/src/condition.rs
+++ b/arch/src/condition.rs
@@ -40,7 +40,7 @@ pub enum Condition {
 #[derive(Debug, Clone, PartialEq)]
 /// If then Else block
 /// 
-/// This type defines how to [`Parse`](ITCondition::parse)
+/// This type defines how to [`Parse`](ITCondition::from)
 /// the condition vector from a base [`Condition`] and a mask.
 pub struct ITCondition {
     /// The conditions that need to be satisfied for

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -26,10 +26,10 @@ pub use set_flags::SetFlags;
 #[derive(Debug, Clone)]
 /// Enumerates all of the possible errors in this crate.
 pub enum ArchError {
-    /// Thrown when trying to parse a [`Condition`](condition::Condition) from
+    /// Thrown when trying to parse a [`Condition`] from
     /// an invalid encoding.
     InvalidCondition,
-    /// Thrown when trying to parse a [`Register`](register::Register) from an
+    /// Thrown when trying to parse a [`Register`] from an
     /// invalid encoding.
     InvalidRegister(u8),
     /// Thrown when trying to parse a specific field type from an invalid

--- a/decoder.md
+++ b/decoder.md
@@ -1,0 +1,6 @@
+<h1 align="center">
+  Decoder
+</h1>
+
+Aside from the parsing this crate also provides a translator from the intermediate representation provided by [operation](./operation/) to
+symex `general_assembly`. This is done using the [transpiler](github.com/ivario/transpiler).

--- a/operation/Cargo.toml
+++ b/operation/Cargo.toml
@@ -2,8 +2,15 @@
 name = "operation"
 version = "1.0.0"
 edition = "2021"
+authors = [
+	"Ivar Jönsson <ivajns-9@student.ltu.se>"
+]
+repository = "https://github.com/ivario123/disarmv7"
+license-file = "../LICENSE"
+keywords = ["disassembly", "embedded", "arm", "armv7"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "Enumerates the instructions in the Armv7 instruction set."
+readme = "README.md"
 
 [dependencies]
 builder_derive = {git="https://github.com/ivario123/builder_derive"}

--- a/operation/Cargo.toml
+++ b/operation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "operation"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/operation/src/lib.rs
+++ b/operation/src/lib.rs
@@ -1,14 +1,12 @@
-#[rustfmt::skip]
 use arch::{
     condition::{Condition, ITCondition},
+    coproc::CoProcessor,
     register::{Register, RegisterList},
     shift::ImmShift,
-    SetFlags,
-    coproc::CoProcessor,
     wrapper_types::*,
+    SetFlags,
 };
 use builder_derive::{Builder, Consumer};
-
 
 /// dsl for defining statemetent in a similar manner to the documentations
 macro_rules! operation{
@@ -111,6 +109,8 @@ operation!(
 
     Cbz {non:bool}, <rn: Register>, <imm:u32>
 
+    Cdp <coproc: CoProcessor>, <opc1:u8>, <crd:u8>, <crn:u8>, <crm:u8>, <opc2: u8>
+
     Clrex <>
 
     Clz <rd: Register>, <rm: Register>
@@ -200,7 +200,7 @@ operation!(
     Ldrt <rt: Register>, <rn: Register>, {imm: u32}
 
     LdcImmediate <coproc: CoProcessor>, <crd:u8>, <rn: Register>, {imm:u32}, <add:bool>, <w: bool>, <index:bool>
-    
+
     LdcLiteral   <coproc: CoProcessor>, <crd:u8>, <imm:u32>, <add:bool>, <index:bool>
 
     LslImmediate {s: SetFlags}, <rd: Register>, <rm: Register>, <imm:u8>
@@ -213,8 +213,10 @@ operation!(
 
 
     // ==================================== M ====================================
-    
+
     Mcrr <coproc: CoProcessor>, <opc1: u8>, <rt:Register>, <rt2: Register>, <crm: u8>
+
+    Mcr  <coproc: CoProcessor>, <opc1: u8>, {opc2: u8}, <rt:Register>, <crm: u8>, <crn: u8>
 
     Mla <rd: Register>, <rn: Register>, <rm: Register>, <ra: Register>
 
@@ -227,6 +229,7 @@ operation!(
     Movt <rd: Register>, <imm:u16>
 
     Mrrc <coproc: CoProcessor>, <opc1: u8>, <rt:Register>, <rt2: Register>, <crm: u8>
+    Mrc  <coproc: CoProcessor>, <opc1: u8>, {opc2: u8}, <rt:Register>, <crm: u8>, <crn: u8>
 
     Mrs <rd: Register>, <sysm: u8>
 
@@ -489,10 +492,7 @@ operation!(
     // These are left for the future as they are not yet supported in SYMEX
 
     Svx <>
-    Mcr <>
-    Mrc <>
 
-    Cdp <>
 
 
 

--- a/operation/src/lib.rs
+++ b/operation/src/lib.rs
@@ -4,6 +4,7 @@ use arch::{
     register::{Register, RegisterList},
     shift::ImmShift,
     SetFlags,
+    coproc::CoProcessor,
     wrapper_types::*,
 };
 use builder_derive::{Builder, Consumer};
@@ -198,6 +199,10 @@ operation!(
 
     Ldrt <rt: Register>, <rn: Register>, {imm: u32}
 
+    LdcImmediate <coproc: CoProcessor>, <crd:u8>, <rn: Register>, {imm:u32}, <add:bool>, <w: bool>, <index:bool>
+    
+    LdcLiteral   <coproc: CoProcessor>, <crd:u8>, <imm:u32>, <add:bool>, <index:bool>
+
     LslImmediate {s: SetFlags}, <rd: Register>, <rm: Register>, <imm:u8>
 
     LslRegister {s: SetFlags}, <rd: Register>, <rn: Register>, <rm: Register>
@@ -208,6 +213,8 @@ operation!(
 
 
     // ==================================== M ====================================
+    
+    Mcrr <coproc: CoProcessor>, <opc1: u8>, <rt:Register>, <rt2: Register>, <crm: u8>
 
     Mla <rd: Register>, <rn: Register>, <rm: Register>, <ra: Register>
 
@@ -219,9 +226,11 @@ operation!(
 
     Movt <rd: Register>, <imm:u16>
 
-    Mrs <rd: Register>, <sysm: u8> // Probably not needed
+    Mrrc <coproc: CoProcessor>, <opc1: u8>, <rt:Register>, <rt2: Register>, <crm: u8>
 
-    Msr <rn: Register>, <mask:Imm2>, <sysm:u8> // Probably not needed
+    Mrs <rd: Register>, <sysm: u8>
+
+    Msr <rn: Register>, <mask:Imm2>, <sysm:u8>
 
     Mul {s: SetFlags}, {rd: Register}, <rn: Register>, <rm: Register>
 
@@ -377,6 +386,8 @@ operation!(
 
     SubImmediate        {s: SetFlags}, {rd: Register}, <rn: Register>, <imm: u32>
     SubRegister         {s: SetFlags}, {rd: Register}, <rn: Register>, <rm: Register>, {shift: ImmShift}
+    Stc             <coproc: CoProcessor>, <crd:u7>, <rn: Register>, {imm:u32}, <add:bool>, <w: bool>, <index:bool>
+
     SubSpMinusImmediate  {s: bool}, {rd: Register}, <imm:u32>
     SubSpMinusRegister       {s: bool}, {rd: Register}, <rm: Register>, {shift: ImmShift}
 
@@ -478,14 +489,10 @@ operation!(
     // These are left for the future as they are not yet supported in SYMEX
 
     Svx <>
-    Stc <>
     Mcr <>
     Mrc <>
-    Mrrc <>
-    Mcrr <>
 
     Cdp <>
-    Ldc<>
 
 
 

--- a/operation/src/lib.rs
+++ b/operation/src/lib.rs
@@ -386,7 +386,7 @@ operation!(
 
     SubImmediate        {s: SetFlags}, {rd: Register}, <rn: Register>, <imm: u32>
     SubRegister         {s: SetFlags}, {rd: Register}, <rn: Register>, <rm: Register>, {shift: ImmShift}
-    Stc             <coproc: CoProcessor>, <crd:u7>, <rn: Register>, {imm:u32}, <add:bool>, <w: bool>, <index:bool>
+    Stc                 <coproc: CoProcessor>, <crd:u8>, <rn: Register>, {imm:u32}, <add:bool>, <w: bool>, <index:bool>
 
     SubSpMinusImmediate  {s: bool}, {rd: Register}, <imm:u32>
     SubSpMinusRegister       {s: bool}, {rd: Register}, <rm: Register>, {shift: ImmShift}

--- a/operation/src/lib.rs
+++ b/operation/src/lib.rs
@@ -336,6 +336,7 @@ operation!(
     Sel {rd: Register}, <rn: Register>, <rm: Register>
 
     Sev <>
+    Svc <imm:u8>
 
     Shadd16 {rd: Register}, <rn: Register>, <rm: Register>
 
@@ -473,28 +474,4 @@ operation!(
     // ==================================== Y ====================================
 
     Yield <>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    // ================================== TODO! ==================================
-    // These are left for the future as they are not yet supported in SYMEX
-
-    Svx <>
-
-
-
-
-
 );

--- a/src/asm/b16/a_5_8.rs
+++ b/src/asm/b16/a_5_8.rs
@@ -11,7 +11,7 @@ instruction!(
         cond as u8 : Condition : 8->11 try_into
     },
     Svc : {
-        _imm8 as u8 :u8 : 0->7
+        imm8 as u8 :u8 : 0->7
     }
 );
 
@@ -50,7 +50,7 @@ impl ToOperation for A5_8 {
                     .complete()
                     .into()
             }
-            Self::Svc(_el) => todo!("This is missing from the operation enum"),
+            Self::Svc(el) => operation::Svc::builder().set_imm(el.imm8).complete().into(),
         }
     }
 }

--- a/src/asm/b32.rs
+++ b/src/asm/b32.rs
@@ -19,7 +19,12 @@ pub mod a5_28;
 pub mod a5_29;
 pub mod a5_30;
 
-use crate::{asm::Mask, Parse, ParseError, ToOperation};
+use crate::{
+    asm::{b32::a5_30::A5_30, Mask},
+    Parse,
+    ParseError,
+    ToOperation,
+};
 
 /// A 32-bit wide instruction
 pub enum B32 {}
@@ -118,17 +123,8 @@ impl B32 {
         }
 
         if op2 >> 6 == 1 {
-            println!(
-                "
-instr: 0b{:32b}
-op1 : 0b{:02b}
-op2 : 0b{:07b}
-op  : 0b{:01b}
-                     ",
-                word, op1, op2, op
-            );
             // Co processor things
-            return Err(ParseError::IncompleteParser);
+            return Ok(A5_30::parse(iter)?.encoding_specific_operations());
         }
 
         Err(ParseError::Invalid32Bit(""))

--- a/src/asm/b32/a5_30.rs
+++ b/src/asm/b32/a5_30.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use arch::CoProcessor;
+use operation::{Cdp, LdcImmediate, LdcLiteral, Mcr, Mcrr, Mrc, Mrrc, Stc};
 use paste::paste;
 
 use crate::{
@@ -122,7 +123,7 @@ instruction!(
         coproc as u8    : CoProcessor: 8 -> 11 try_into,
         rt as u8        : Register  : 12 -> 15 try_into,
         crn as u8       : u8        : 16 -> 19,
-        opc1 as u8      : u8        : 20 -> 23
+        opc1 as u8      : u8        : 21 -> 23
     },
     McrT2 : {
         crm as u8       : u8        : 0 -> 3,
@@ -130,7 +131,7 @@ instruction!(
         coproc as u8    : CoProcessor: 8 -> 11 try_into,
         rt as u8        : Register  : 12 -> 15 try_into,
         crn as u8       : u8        : 16 -> 19,
-        opc1 as u8      : u8        : 20 -> 23
+        opc1 as u8      : u8        : 21 -> 23
     },
     MrcT1 : {
         crm as u8       : u8        : 0 -> 3,
@@ -138,7 +139,7 @@ instruction!(
         coproc as u8    : CoProcessor: 8 -> 11 try_into,
         rt as u8        : Register  : 12 -> 15 try_into,
         crn as u8       : u8        : 16 -> 19,
-        opc1 as u8      : u8        : 20 -> 23
+        opc1 as u8      : u8        : 21 -> 23
     },
     MrcT2 : {
         crm as u8       : u8        : 0 -> 3,
@@ -146,7 +147,7 @@ instruction!(
         coproc as u8    : CoProcessor: 8 -> 11 try_into,
         rt as u8        : Register  : 12 -> 15 try_into,
         crn as u8       : u8        : 16 -> 19,
-        opc1 as u8      : u8        : 20 -> 23
+        opc1 as u8      : u8        : 21 -> 23
     }
 );
 
@@ -171,15 +172,6 @@ impl Parse for A5_30 {
         let rn = word.mask::<16, 19>();
         assert!(rn < (1 << (19 - 16 + 1)));
 
-        match (enc + 1, op1 & 0b100001, rn) {
-            (1, 0b000000, _) => return Ok(Self::StcT1(StcT1::parse(iter)?)),
-            (2, 0b000000, _) => return Ok(Self::StcT2(StcT2::parse(iter)?)),
-            (1, 0b000001, 0b1111) => return Ok(Self::LdcLiteralT1(LdcLiteralT1::parse(iter)?)),
-            (2, 0b000001, 0b1111) => return Ok(Self::LdcLiteralT2(LdcLiteralT2::parse(iter)?)),
-            (1, 0b000001, _) => return Ok(Self::LdcImmediateT1(LdcImmediateT1::parse(iter)?)),
-            (2, 0b000001, _) => return Ok(Self::LdcImmediateT2(LdcImmediateT2::parse(iter)?)),
-            _ => {}
-        }
         if op1 == 0b000100 {
             match enc + 1 {
                 1 => return Ok(Self::McrrT1(McrrT1::parse(iter)?)),
@@ -194,16 +186,25 @@ impl Parse for A5_30 {
                 _ => unreachable!("This is unreachable due to previous asserts"),
             }
         }
-        match (enc + 1, op1 & 0b110000) {
-            (1, 0b100000) => return Ok(Self::CdpT1(CdpT1::parse(iter)?)),
-            (2, 0b100000) => return Ok(Self::CdpT2(CdpT2::parse(iter)?)),
+        match (enc + 1, op1 & 0b110001, op) {
+            (1, 0b100000, 1) => return Ok(Self::McrT1(McrT1::parse(iter)?)),
+            (2, 0b100000, 1) => return Ok(Self::McrT2(McrT2::parse(iter)?)),
+            (1, 0b100001, 1) => return Ok(Self::MrcT1(MrcT1::parse(iter)?)),
+            (2, 0b100001, 1) => return Ok(Self::MrcT2(MrcT2::parse(iter)?)),
             _ => {}
         }
-        match (enc + 1, op1 & 0b110001) {
-            (1, 0b100000) => return Ok(Self::McrT1(McrT1::parse(iter)?)),
-            (2, 0b100000) => return Ok(Self::McrT2(McrT2::parse(iter)?)),
-            (1, 0b100001) => return Ok(Self::MrcT1(MrcT1::parse(iter)?)),
-            (2, 0b100001) => return Ok(Self::MrcT2(MrcT2::parse(iter)?)),
+        match (enc + 1, op1 & 0b110000, op) {
+            (1, 0b100000, 0) => return Ok(Self::CdpT1(CdpT1::parse(iter)?)),
+            (2, 0b100000, 0) => return Ok(Self::CdpT2(CdpT2::parse(iter)?)),
+            _ => {}
+        }
+        match (enc + 1, op1 & 0b100001, rn) {
+            (1, 0b000000, _) => return Ok(Self::StcT1(StcT1::parse(iter)?)),
+            (2, 0b000000, _) => return Ok(Self::StcT2(StcT2::parse(iter)?)),
+            (1, 0b000001, 0b1111) => return Ok(Self::LdcLiteralT1(LdcLiteralT1::parse(iter)?)),
+            (2, 0b000001, 0b1111) => return Ok(Self::LdcLiteralT2(LdcLiteralT2::parse(iter)?)),
+            (1, 0b000001, _) => return Ok(Self::LdcImmediateT1(LdcImmediateT1::parse(iter)?)),
+            (2, 0b000001, _) => return Ok(Self::LdcImmediateT2(LdcImmediateT2::parse(iter)?)),
             _ => {}
         }
         Err(ParseError::Invalid32Bit("a5_30"))
@@ -212,12 +213,528 @@ impl Parse for A5_30 {
 impl ToOperation for A5_30 {
     fn encoding_specific_operations(self) -> operation::Operation {
         println!("A5_30 : {self:?}");
-        todo!("Encodings");
+        match self {
+            Self::StcT1(stc) => Stc::builder()
+                .set_coproc(stc.coproc)
+                .set_crd(stc.crd)
+                .set_rn(stc.rn)
+                .set_imm(Some((stc.imm8 as u32) << 2))
+                .set_add(stc.u)
+                .set_w(stc.w)
+                .set_index(stc.p)
+                .complete()
+                .into(),
+            Self::StcT2(stc) => Stc::builder()
+                .set_coproc(stc.coproc)
+                .set_crd(stc.crd)
+                .set_rn(stc.rn)
+                .set_imm(Some((stc.imm8 as u32) << 2))
+                .set_add(stc.u)
+                .set_w(stc.w)
+                .set_index(stc.p)
+                .complete()
+                .into(),
+            Self::LdcLiteralT1(ldc) => LdcLiteral::builder()
+                .set_coproc(ldc.coproc)
+                .set_crd(ldc.crd)
+                .set_imm((ldc.imm8 as u32) << 2)
+                .set_add(ldc.u)
+                .set_index(ldc.p)
+                .complete()
+                .into(),
+            Self::LdcLiteralT2(ldc) => LdcLiteral::builder()
+                .set_coproc(ldc.coproc)
+                .set_crd(ldc.crd)
+                .set_imm((ldc.imm8 as u32) << 2)
+                .set_add(ldc.u)
+                .set_index(ldc.p)
+                .complete()
+                .into(),
+            Self::LdcImmediateT1(ldc) => LdcImmediate::builder()
+                .set_coproc(ldc.coproc)
+                .set_crd(ldc.crd)
+                .set_imm(Some((ldc.imm8 as u32) << 2))
+                .set_add(ldc.u)
+                .set_index(ldc.p)
+                .set_rn(ldc.rn)
+                .set_w(ldc.w)
+                .complete()
+                .into(),
+            Self::LdcImmediateT2(ldc) => LdcImmediate::builder()
+                .set_coproc(ldc.coproc)
+                .set_crd(ldc.crd)
+                .set_imm(Some((ldc.imm8 as u32) << 2))
+                .set_add(ldc.u)
+                .set_index(ldc.p)
+                .set_rn(ldc.rn)
+                .set_w(ldc.w)
+                .complete()
+                .into(),
+            Self::MrrcT1(el) => Mrrc::builder()
+                .set_coproc(el.coproc)
+                .set_opc1(el.opc1)
+                .set_rt(el.rt)
+                .set_rt2(el.rt2)
+                .set_crm(el.crm)
+                .complete()
+                .into(),
+            Self::MrrcT2(el) => Mrrc::builder()
+                .set_coproc(el.coproc)
+                .set_opc1(el.opc1)
+                .set_rt(el.rt)
+                .set_rt2(el.rt2)
+                .set_crm(el.crm)
+                .complete()
+                .into(),
+            Self::CdpT1(el) => Cdp::builder()
+                .set_coproc(el.coproc)
+                .set_opc1(el.opc1)
+                .set_crm(el.crm)
+                .set_crd(el.crd)
+                .set_crn(el.crn)
+                .set_opc2(el.opc2)
+                .complete()
+                .into(),
+            Self::CdpT2(el) => Cdp::builder()
+                .set_coproc(el.coproc)
+                .set_opc1(el.opc1)
+                .set_crm(el.crm)
+                .set_crd(el.crd)
+                .set_crn(el.crn)
+                .set_opc2(el.opc2)
+                .complete()
+                .into(),
+            Self::McrT1(el) => Mcr::builder()
+                .set_coproc(el.coproc)
+                .set_opc1(el.opc1)
+                .set_crm(el.crm)
+                .set_opc2(Some(el.opc2))
+                .set_rt(el.rt)
+                .set_crn(el.crn)
+                .complete()
+                .into(),
+            Self::McrT2(el) => Mcr::builder()
+                .set_coproc(el.coproc)
+                .set_opc1(el.opc1)
+                .set_crm(el.crm)
+                .set_opc2(Some(el.opc2))
+                .set_rt(el.rt)
+                .set_crn(el.crn)
+                .complete()
+                .into(),
+            Self::MrcT1(el) => Mrc::builder()
+                .set_coproc(el.coproc)
+                .set_opc1(el.opc1)
+                .set_crm(el.crm)
+                .set_opc2(Some(el.opc2))
+                .set_rt(el.rt)
+                .set_crn(el.crn)
+                .complete()
+                .into(),
+            Self::MrcT2(el) => Mrc::builder()
+                .set_coproc(el.coproc)
+                .set_opc1(el.opc1)
+                .set_crm(el.crm)
+                .set_opc2(Some(el.opc2))
+                .set_rt(el.rt)
+                .set_crn(el.crn)
+                .complete()
+                .into(),
+            Self::McrrT1(el) => Mcrr::builder()
+                .set_coproc(el.coproc)
+                .set_opc1(el.opc1)
+                .set_rt(el.rt)
+                .set_rt2(el.rt2)
+                .set_crm(el.crm)
+                .complete()
+                .into(),
+            Self::McrrT2(el) => Mcrr::builder()
+                .set_coproc(el.coproc)
+                .set_opc1(el.opc1)
+                .set_rt(el.rt)
+                .set_rt2(el.rt2)
+                .set_crm(el.crm)
+                .complete()
+                .into(),
+        }
     }
 }
-
 #[cfg(test)]
 mod test {
-    // TODO! Add in tests when ever the operation set supports these
-    // instructions
+
+    use crate::prelude::*;
+
+    #[test]
+    fn test_parse_stc() {
+        let mut bin = vec![];
+        // P = 1;
+        // U = 1;
+        // N = 1;
+        // W = 0;
+        bin.extend([0b1110_1101u8, 0b1100_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0000_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Stc::builder()
+            .set_coproc(coproc)
+            .set_crd(1)
+            .set_rn(Register::R2)
+            .set_imm(Some(0b1100))
+            .set_add(true)
+            .set_w(false)
+            .set_index(true)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_stc2() {
+        let mut bin = vec![];
+        // P = 1;
+        // U = 1;
+        // N = 1;
+        // W = 0;
+        bin.extend([0b1110_1101u8, 0b1100_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0000_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Stc::builder()
+            .set_coproc(coproc)
+            .set_crd(1)
+            .set_rn(Register::R2)
+            .set_imm(Some(0b1100))
+            .set_add(true)
+            .set_w(false)
+            .set_index(true)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_ldc_imm() {
+        let mut bin = vec![];
+        // P = 1;
+        // U = 1;
+        // N = 1;
+        // W = 0;
+        bin.extend([0b1110_1101u8, 0b1101_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0000_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::LdcImmediate::builder()
+            .set_coproc(coproc)
+            .set_crd(1)
+            .set_rn(Register::R2)
+            .set_imm(Some(0b1100))
+            .set_add(true)
+            .set_w(false)
+            .set_index(true)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_ldc_imm2() {
+        let mut bin = vec![];
+        // P = 1;
+        // U = 1;
+        // N = 1;
+        // W = 0;
+        bin.extend([0b1111_1101u8, 0b1101_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0000_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::LdcImmediate::builder()
+            .set_coproc(coproc)
+            .set_crd(1)
+            .set_rn(Register::R2)
+            .set_imm(Some(0b1100))
+            .set_add(true)
+            .set_w(false)
+            .set_index(true)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_ldc_literal() {
+        let mut bin = vec![];
+        // P = 1;
+        // U = 1;
+        // N = 1;
+        // W = 0;
+        bin.extend([0b1110_1101u8, 0b1101_1111u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0000_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::LdcLiteral::builder()
+            .set_coproc(coproc)
+            .set_crd(1)
+            .set_imm(0b1100)
+            .set_add(true)
+            .set_index(true)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_ldc_literal2() {
+        let mut bin = vec![];
+        // P = 1;
+        // U = 1;
+        // N = 1;
+        // W = 0;
+        bin.extend([0b1111_1101u8, 0b1101_1111u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0000_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::LdcLiteral::builder()
+            .set_coproc(coproc)
+            .set_crd(1)
+            .set_imm(0b1100)
+            .set_add(true)
+            .set_index(true)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_mcrr() {
+        let mut bin = vec![];
+        // P = 1;
+        // U = 1;
+        // N = 1;
+        // W = 0;
+        bin.extend([0b1110_1100u8, 0b0100_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0100_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Mcrr::builder()
+            .set_coproc(coproc)
+            .set_rt(Register::R1)
+            .set_rt2(Register::R2)
+            .set_opc1(0b0100)
+            .set_crm(0b0011)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_mcrr2() {
+        let mut bin = vec![];
+        // P = 1;
+        // U = 1;
+        // N = 1;
+        // W = 0;
+        bin.extend([0b1111_1100u8, 0b0100_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0100_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Mcrr::builder()
+            .set_coproc(coproc)
+            .set_rt(Register::R1)
+            .set_rt2(Register::R2)
+            .set_opc1(0b0100)
+            .set_crm(0b0011)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_mrrc() {
+        let mut bin = vec![];
+        // P = 1;
+        // U = 1;
+        // N = 1;
+        // W = 0;
+        bin.extend([0b1110_1100u8, 0b0101_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0100_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Mrrc::builder()
+            .set_coproc(coproc)
+            .set_rt(Register::R1)
+            .set_rt2(Register::R2)
+            .set_opc1(0b0100)
+            .set_crm(0b0011)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_mrrc2() {
+        let mut bin = vec![];
+        // P = 1;
+        // U = 1;
+        // N = 1;
+        // W = 0;
+        bin.extend([0b1111_1100u8, 0b0101_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0100_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Mrrc::builder()
+            .set_coproc(coproc)
+            .set_rt(Register::R1)
+            .set_rt2(Register::R2)
+            .set_opc1(0b0100)
+            .set_crm(0b0011)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_cdp() {
+        let mut bin = vec![];
+        bin.extend([0b1110_1110u8, 0b0101_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0100_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Cdp::builder()
+            .set_coproc(coproc)
+            .set_opc1(0b0101)
+            .set_crd(0b0001)
+            .set_crn(0b0010)
+            .set_crm(0b0011)
+            .set_opc2(0b010)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_cdp2() {
+        let mut bin = vec![];
+        bin.extend([0b1111_1110u8, 0b0101_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0100_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Cdp::builder()
+            .set_coproc(coproc)
+            .set_opc1(0b0101)
+            .set_crd(0b0001)
+            .set_crn(0b0010)
+            .set_crm(0b0011)
+            .set_opc2(0b010)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_mcr() {
+        let mut bin = vec![];
+        bin.extend([0b1110_1110u8, 0b0100_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0101_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Mcr::builder()
+            .set_coproc(coproc)
+            .set_rt(Register::R1)
+            .set_opc1(0b010)
+            .set_crm(0b0011)
+            .set_opc2(Some(0b010))
+            .set_crn(0b0010)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_mcr2() {
+        let mut bin = vec![];
+        bin.extend([0b1111_1110u8, 0b0100_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0101_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Mcr::builder()
+            .set_coproc(coproc)
+            .set_rt(Register::R1)
+            .set_opc1(0b010)
+            .set_crm(0b0011)
+            .set_opc2(Some(0b010))
+            .set_crn(0b0010)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_mrc() {
+        let mut bin = vec![];
+        bin.extend([0b1110_1110u8, 0b0101_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0101_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Mrc::builder()
+            .set_coproc(coproc)
+            .set_rt(Register::R1)
+            .set_opc1(0b010)
+            .set_crm(0b0011)
+            .set_opc2(Some(0b010))
+            .set_crn(0b0010)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
+
+    #[test]
+    fn test_parse_mrc2() {
+        let mut bin = vec![];
+        bin.extend([0b1111_1110u8, 0b0101_0010u8].into_iter().rev());
+        bin.extend([0b0001_0010u8, 0b0101_0011u8].into_iter().rev());
+
+        let mut stream = PeekableBuffer::from(bin.into_iter());
+        let instr = Operation::parse(&mut stream).expect("Parser broken").1;
+        let coproc = arch::CoProcessor::P2;
+        let target: Operation = operation::Mrc::builder()
+            .set_coproc(coproc)
+            .set_rt(Register::R1)
+            .set_opc1(0b010)
+            .set_crm(0b0011)
+            .set_opc2(Some(0b010))
+            .set_crn(0b0010)
+            .complete()
+            .into();
+        assert_eq!(instr, target)
+    }
 }


### PR DESCRIPTION
# Add in co-processor instructions

This PR aims to implement the missing co-processor instructions.
It adds in the remaining co-processor instructions.

## Future work

After this PR is merged the co-processor crate will be version 1.0.0 only leaving behind a few stabilisation merges before we can consider release to crates.io.  However, there is still work to be done, there is currently no support for the floating point extension (#4) which would be nice to have but not needed as this crate is mainly aimed at no-std targets where floating point is rare.

## Side-effects

closes #5